### PR TITLE
fix: Prevent iOS' status bar to disappear when opening the keyboard

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -497,7 +497,8 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
 
     _isFullScreenVideoOpen = YES;
     RCTUnsafeExecuteOnMainQueueSync(^{
-      [RCTSharedApplication() setStatusBarStyle:self->_savedStatusBarStyle animated:YES];
+      [RCTSharedApplication() setStatusBarHidden:NO animated:YES];
+      [RCTSharedApplication() setStatusBarStyle:RCTSharedApplication().statusBarStyle animated:YES];
     });
 #pragma clang diagnostic pop
 }
@@ -511,8 +512,8 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
 
     _isFullScreenVideoOpen = NO;
     RCTUnsafeExecuteOnMainQueueSync(^{
-      [RCTSharedApplication() setStatusBarHidden:self->_savedStatusBarHidden animated:YES];
-      [RCTSharedApplication() setStatusBarStyle:self->_savedStatusBarStyle animated:YES];
+      [RCTSharedApplication() setStatusBarHidden:NO animated:YES];
+      [RCTSharedApplication() setStatusBarStyle:RCTSharedApplication().statusBarStyle animated:YES];
     });
 #pragma clang diagnostic pop
 }


### PR DESCRIPTION
This PR retrieve a fix from cozy/cozy-react-native#306 that was based on npm [patch-package](https://www.npmjs.com/package/patch-package). Now it is fully part of our fork.

Based on: https://github.com/react-native-webview/react-native-webview/issues/735#issuecomment-581574089

Related PR: cozy/cozy-react-native#306