### PR TITLE
feat: Do not gitignore `/lib` to allow using this Github as NPM source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,6 @@ android/gradle
 android/gradlew
 android/gradlew.bat
 
-lib/
 .classpath
 .project
 .settings/


### PR DESCRIPTION
To use this lib in our project we will `yarn build` and commit `/lib`
content

This will allow us to add this lib in the `package.json` by using the
Github URL

We cannot use the `prepare` entry from `package.json` due to a bug when
using Github as source with yarn 1.x (cf yarnpkg/yarn#5235)