### PR TITLE
fix: Set correct casing for `WebViewOpenWindow.targetUrl` type

### DIFF
--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -146,7 +146,7 @@ export interface WebViewRenderProcessGoneDetail {
 }
 
 export interface WebViewOpenWindow {
-  targeturl: string;
+  targetUrl: string;
 }
 
 export type WebViewEvent = NativeSyntheticEvent<WebViewNativeEvent>;


### PR DESCRIPTION
Note: this is a fix from the original PR on forked repo