### PR TITLE
fix: Make compatible with Android 13  (SDK 33)

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -297,17 +297,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   @ReactProp(name = "cacheEnabled")
   public void setCacheEnabled(WebView view, boolean enabled) {
-    if (enabled) {
-      Context ctx = view.getContext();
-      if (ctx != null) {
-        view.getSettings().setAppCachePath(ctx.getCacheDir().getAbsolutePath());
-        view.getSettings().setCacheMode(WebSettings.LOAD_DEFAULT);
-        view.getSettings().setAppCacheEnabled(true);
-      }
-    } else {
-      view.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
-      view.getSettings().setAppCacheEnabled(false);
-    }
+    view.getSettings().setCacheMode(enabled ? WebSettings.LOAD_DEFAULT : WebSettings.LOAD_NO_CACHE);
   }
 
   @ReactProp(name = "cacheMode")
@@ -505,7 +495,6 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     // Disable caching
     view.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
-    view.getSettings().setAppCacheEnabled(false);
     view.clearHistory();
     view.clearCache(true);
 


### PR DESCRIPTION
Make react-native-webview compatible with Android SDK 33 by removing deprecated calls to `setAppCacheEnabled`

Related PR: react-native-webview/react-native-webview#2583
Related PR: react-native-webview/react-native-webview#2697